### PR TITLE
fix data loss bug + histogram correctness tests

### DIFF
--- a/histogram/histogram.go
+++ b/histogram/histogram.go
@@ -2,7 +2,6 @@ package histogram
 
 import (
 	"container/heap"
-	"fmt"
 	"math"
 	"sort"
 )
@@ -38,7 +37,16 @@ func (bs *Bins) Pop() interface{} {
 func (bs *Bins) remove(n int) *Bin {
 	old := *bs
 	x := old[n]
-	*bs = old[0:n]
+	h := old[0:n]
+	if n < len(old)-1 {
+		t := old[n+1:]
+		out := make([]*Bin, len(old)-1)
+		copy(out, h)
+		copy(out[len(h):], t)
+		*bs = out
+	} else {
+		*bs = h
+	}
 	return x
 }
 
@@ -94,7 +102,6 @@ func (r *reservoir) compress() {
 		}
 		prev := r.bins[minGapIndex]
 		next := r.bins.remove(minGapIndex + 1)
-		fmt.Println("%#v", next)
 		prev.Update(next)
 	}
 }

--- a/histogram/histogram_test.go
+++ b/histogram/histogram_test.go
@@ -32,4 +32,3 @@ func count(bins Bins) int {
 	}
 	return binCounts
 }
-


### PR DESCRIPTION
1) verify bin count is <= maxBins not ==
2) ensure that the number of points in all bins is the number of points recorded
3) avoid losing data when compressing bins in the middle of a slice
