### PR TITLE
Gave `topk` some love

### DIFF
--- a/topk/topk.go
+++ b/topk/topk.go
@@ -1,85 +1,160 @@
+// An implementation of the SpaceSaving algorithm for computing an approximate
+// solution to the problem of finding the most frequent items in a
+// data stream.
+//
+// This implementation is based on 'Efficient Computation of Frequent and Top-k
+// Elements in Data Streams'
+// (http://www.cs.ucsb.edu/research/tech_reports/reports/2005-23.pdf) but
+// doesn't use the StreamSummary data structure introduced by the authors.
+// Instead, it maintains a heap of the inserted elements, indexed by a plain old
+// `map` for quick lookups.
+//
+// (For a simplified explanation of the algorithm, see
+// http://boundary.com/blog/2013/05/14/approximate-heavy-hitters-the-spacesaving-algorithm/)
 package topk
 
 import (
+	"container/heap"
 	"sort"
 )
 
-// http://www.cs.ucsb.edu/research/tech_reports/reports/2005-23.pdf
-
+// A key-count pair
 type Element struct {
+	// The key being tracked
 	Value string
+	// The (approximate) number of times this item has been seen
 	Count int
+	// The upper bound on the error of this count
+	Error int
+	// The index of this element in the tkheap.
+	index int
 }
 
-type Samples []*Element
+// An element heap. Implements heap.Interface for convenience, but in practice,
+// just the Init (aka heapify) method will be used. Since the heap will be
+// initialized once and then remain a fixed size, elements need to be sifted
+// down the heap as updates to their counts arrive.
+type tkheap []*Element
 
-func (sm Samples) Len() int {
-	return len(sm)
+func (h tkheap) Len() int {
+	return len(h)
 }
 
-func (sm Samples) Less(i, j int) bool {
-	return sm[i].Count < sm[j].Count
+func (h tkheap) Less(i, j int) bool {
+	return h[i].Count < h[j].Count
 }
 
-func (sm Samples) Swap(i, j int) {
-	sm[i], sm[j] = sm[j], sm[i]
+func (h tkheap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+	h[i].index = i
+	h[j].index = j
 }
 
+func (h *tkheap) Push(x interface{}) {
+	n := len(*h)
+	e := x.(*Element)
+	e.index = n
+	*h = append(*h, e)
+}
+
+// Unused, but neccessary for heap.Interface
+func (h *tkheap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	e := old[n-1]
+	e.index = -1 // just in case
+	*h = old[0 : n-1]
+	return e
+}
+
+func siftDown(h tkheap, i int) {
+	n := len(h)
+	for {
+		left := 2*i + 1
+		if left > n || left < 0 { // overflow
+			break
+		}
+		smallest := left
+		if right := left + 1; right < n && h.Less(right, left) {
+			smallest = right
+		}
+
+		if h.Less(i, smallest) {
+			break
+		}
+		h.Swap(i, smallest)
+		i = smallest
+	}
+}
+
+// TODO: DOC ME
 type Stream struct {
-	k   int
-	mon map[string]*Element
-
-	// the minimum Element
-	min *Element
+	n      int
+	size   int
+	tkheap tkheap
+	lookup map[string]*Element
 }
 
-func New(k int) *Stream {
+// Create a new sketch that monitors up to `size` elements
+func New(size int) *Stream {
 	s := new(Stream)
-	s.k = k
-	s.mon = make(map[string]*Element)
-	s.min = &Element{}
-
-	// Track k+1 so that less frequenet items contended for that spot,
-	// resulting in k being more accurate.
+	s.size = size
+	s.tkheap = make([]*Element, 0, size) // length 0, capacity k.
+	s.lookup = make(map[string]*Element)
 	return s
 }
 
+// The number of distinct items being monitored
+func (s *Stream) Len() int {
+	return len(s.tkheap)
+}
+
+// The number of items in the data stream
+func (s *Stream) N() int {
+	return s.n
+}
+
+// Insert an item into the sketch
 func (s *Stream) Insert(x string) {
-	s.insert(&Element{x, 1})
+	s.InsertWeighted(x, 1)
 }
 
-func (s *Stream) Merge(sm Samples) {
-	for _, e := range sm {
-		s.insert(e)
-	}
-}
-
-func (s *Stream) insert(in *Element) {
-	e := s.mon[in.Value]
-	if e != nil {
-		e.Count++
+// Insert an item with weight `n` into the sketch
+func (s *Stream) InsertWeighted(x string, n int) {
+	e, found := s.lookup[x]
+	if found {
+		e.Count += n
 	} else {
-		if len(s.mon) < s.k+1 {
-			e = &Element{in.Value, in.Count}
-			s.mon[in.Value] = e
+		if len(s.tkheap) < s.size {
+			e = &Element{Value: x, Count: n, Error: 0}
+			s.tkheap.Push(e)
+			s.lookup[x] = e
+			// Don't bother heapifying until the queue is full
+			if len(s.tkheap) == s.size {
+				heap.Init(&s.tkheap)
+			}
 		} else {
-			e = s.min
-			delete(s.mon, e.Value)
-			e.Value = in.Value
-			e.Count += in.Count
-			s.min = e
+			e = s.tkheap[0]
+			// Make sure the Value of the element is swapped and the lookup is current
+			delete(s.lookup, e.Value)
+			s.lookup[x] = e
+			e.Value = x
+			// The error should be equal to the old count of the element
+			e.Error = e.Count
+			e.Count += n
 		}
 	}
-	if e.Count < s.min.Count {
-		s.min = e
+
+	if len(s.tkheap) == s.size {
+		siftDown(s.tkheap, e.index)
 	}
 }
 
-func (s *Stream) Query() Samples {
-	var sm Samples
-	for _, e := range s.mon {
-		sm = append(sm, e)
-	}
-	sort.Sort(sort.Reverse(sm))
-	return sm[:s.k]
+// Get a copy of all of the items (and their errors) currently monitored by the
+// sketch. Elements will be sorted by Value
+func (s *Stream) Elements() []*Element {
+	var toRet tkheap = make([]*Element, len(s.tkheap))
+	copy(toRet, s.tkheap)
+	sort.Sort(sort.Reverse(toRet))
+	return toRet
 }

--- a/topk/topk_test.go
+++ b/topk/topk_test.go
@@ -3,36 +3,118 @@ package topk
 import (
 	"fmt"
 	"math/rand"
-	"sort"
 	"testing"
 )
 
-func TestTopK(t *testing.T) {
-	stream := New(10)
-	ss := []*Stream{New(10), New(10), New(10)}
-	m := make(map[string]int)
-	for _, s := range ss {
-		for i := 0; i < 1e6; i++ {
-			v := fmt.Sprintf("%x", int8(rand.ExpFloat64()))
-			s.Insert(v)
-			m[v]++
+func randString() string {
+	return fmt.Sprintf("%x", rand.Int63())
+}
+
+// Check that with fewer than the required number of elements, counts are exact
+func TestFewElements(t *testing.T) {
+	sketch := New(20)
+	data := make(map[string]int)
+	for i := 0; i < 10; i++ {
+		key := randString()
+		data[key] = i
+		sketch.InsertWeighted(key, i)
+	}
+
+	elements := sketch.Elements()
+	if len(elements) != len(data) {
+		t.Errorf("expected %d monitored elements, but got %d", len(data), len(elements))
+	}
+	for _, e := range elements {
+		if wanted := data[e.Value]; wanted != e.Count {
+			t.Errorf("%s wanted %d but got %d", e.Value, wanted, e.Value, e.Count)
 		}
-		stream.Merge(s.Query())
+	}
+}
+
+// Test that an element is bumped approximately correctly
+func TestApproximates(t *testing.T) {
+	sketch := New(2)
+	data := []string{"foo", "bar", "baz"}
+	REPEAT := 100
+
+	// Setup expected elements. NOTE: == compares the private `index` value too.
+	// Gotta set that.
+	expected := []*Element{
+		&Element{Value: "baz", Count: (REPEAT + 1) /*actual inserts*/ + 1 /*error*/, Error: 1},
+		&Element{Value: "bar", Count: 1, Error: 0},
+	}
+	for i, e := range expected {
+		e.index = i
 	}
 
-	var sm Samples
-	for x, s := range m {
-		sm = append(sm, &Element{x, s})
+	// Do the deed.
+	for _, d := range data {
+		sketch.Insert(d)
 	}
-	sort.Sort(sort.Reverse(sm))
+	for i := 0; i < REPEAT; i++ {
+		sketch.Insert("baz")
+	}
 
-	g := stream.Query()
-	if len(g) != 10 {
-		t.Fatalf("got %d, want 10", len(g))
+	elements := sketch.Elements()
+	if len(elements) != len(expected) {
+		t.Errorf("expected exactly %d elements", len(expected))
 	}
-	for i, e := range g {
-		if sm[i].Value != e.Value {
-			t.Errorf("at %d: want %q, got %q", i, sm[i].Value, e.Value)
+
+	for i, e := range expected {
+		actual := elements[i]
+		if *e != *actual {
+			t.Errorf("expected: %v, actual: %v", e, actual)
+		}
+	}
+}
+
+// Test that the heap property works
+func TestHeap(t *testing.T) {
+	sketch := New(5)
+	data := []string{"one", "two", "three", "four", "five", "six"}
+
+	// First three items in the sketch have ~~big~~ weight. Next two are
+	// decreasing, but not equal. The last insert should bump up the sketch into
+	// approximate region, and the count of "six" (which replaces "five") should
+	// be larger than the count of "four".
+	big := 300
+	medium := 100
+	small := medium - 1
+
+	for i := 0; i < len(data); i++ {
+		switch i {
+		default:
+			sketch.InsertWeighted(data[i], big + i)
+		case 3:
+			sketch.InsertWeighted(data[i], medium)
+		case 4:
+			sketch.InsertWeighted(data[i], small)
+		case 5:
+			sketch.InsertWeighted(data[i], 5)
+		}
+	}
+
+	expected := []*Element{
+		&Element{Value: "three", Count: big + 2, Error: 0},
+		&Element{Value: "two", Count: big + 1, Error: 0},
+		&Element{Value: "one", Count: big, Error: 0},
+		&Element{Value: "six", Count: small + 5, Error: small},
+		&Element{Value: "four", Count: medium, Error: 0},
+	}
+	for i, e := range expected {
+		e.index = i
+	}
+
+	elements := sketch.Elements()
+	if len(elements) != len(expected) {
+		t.Errorf("expected exactly %d elements", len(expected))
+	}
+
+
+	for i, e := range expected {
+		actual := elements[i]
+		if *e != *actual {
+			t.Errorf("expected: %v, actual: %v", e, actual)
 		}
 	}
 }


### PR DESCRIPTION
I got a little inspired yesterday and gave the `topk` package some love. The version that was here before used a map and a pointer to the minimum element, which *almost* works. Unfortunately it falls apart when you repeatedly update the minimum element so that it's no longer the minumum. I replaced it with a map that indexes into a priority-queue, so that you can always track the minimum element as updates are applied.

There's also a shameless link in there to a blog post I wrote about this paper, but I think it's fairly helpful. ;)