### PR TITLE
Reproduces issue 8

### DIFF
--- a/quantile/regression_test.go
+++ b/quantile/regression_test.go
@@ -1,0 +1,64 @@
+package quantile
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func eqFloat(a, b, diff float64) (isEq bool, eps float64) {
+	eps = math.Abs(a-b) / a
+	isEq = eps < diff
+	return
+}
+
+func similarQueries(t *testing.T, tgts []float64, gt, tested *Stream, diff float64) bool {
+	same := true
+	for _, tgt := range tgts {
+		w := gt.Query(tgt)
+		g := tested.Query(tgt)
+		if isEq, eps := eqFloat(w, g, diff); !isEq {
+			t.Errorf("perc%2.0f: want %v, got %v", tgt*100, w, g)
+			t.Logf("e: %f", eps)
+			same = false
+		}
+	}
+	return same
+}
+
+// https://github.com/bmizerany/perks/issues/8
+func TestDoesntDegradeAfterResets(t *testing.T) {
+	// query should be wildly different
+	diff := 0.99
+
+	// I have a long-running application which has two streams
+	// (set to report 50%, 90%, and 99% quantiles)
+	targets := []float64{0.5, 0.9, 0.99}
+	toReset := NewTargeted(targets...)
+	groundTruth := NewTargeted(targets...)
+
+	// that both receive the same input data (latencies as float64
+	// milliseconds from database operations).
+	minDbQPS, maxDbQPS := 1, 50 // wild guesses
+	queryThisSec := func() int { return rand.Intn(maxDbQPS-minDbQPS) + minDbQPS }
+
+	// wild guess: should happen within a (long!) month
+	secondsToFail := int((time.Hour * 1).Seconds())
+
+	for sec := 0; sec < secondsToFail; sec++ {
+
+		qps := queryThisSec()
+		for i := 0; i < qps; i++ {
+			d := rand.Float64()
+			toReset.Insert(d)
+			groundTruth.Insert(d)
+		}
+		// One stream gets reset each second after reporting a few quantiles
+		// the other one reports at the same time but never gets reset.
+		if ok := similarQueries(t, targets, groundTruth, toReset, diff); !ok {
+			t.Logf("failed at second %d, %d qps", sec, qps)
+		}
+		toReset.Reset()
+	}
+}


### PR DESCRIPTION
r: @bmizerany 
cc: @leifwalsh

This seems to reproduce the situation described in issue #8.

However, I'm not sure if this behavior (near-zero values) is unexpected if the stream is reset often after reading a very few values... but I'm no expert on the domain.  

The output looks like this:

```bash
$ go test ./...
--- FAIL: TestDoesntDegradeAfterResets (2.53 seconds)
	regression_test.go:22: perc50: want 0.5034867900486911, got 0.0014115440248851888
	regression_test.go:23: e: 0.997196
	regression_test.go:60: failed at second 15, 3 qps
	regression_test.go:22: perc50: want 0.48769729658334754, got 0.9819681965218967
	regression_test.go:23: e: 1.013479
	regression_test.go:60: failed at second 799, 1 qps
	regression_test.go:22: perc50: want 0.4886489836954619, got 0.003647536279147103
	regression_test.go:23: e: 0.992535
	regression_test.go:22: perc90: want 0.8853796193381923, got 0.003647536279147103
	regression_test.go:23: e: 0.995880
	regression_test.go:22: perc99: want 0.9791097199218912, got 0.003647536279147103
	regression_test.go:23: e: 0.996275
	regression_test.go:60: failed at second 1530, 1 qps
	regression_test.go:22: perc50: want 0.48757831397216517, got 0.0020130646351263133
	regression_test.go:23: e: 0.995871
	regression_test.go:60: failed at second 2023, 3 qps
	regression_test.go:22: perc99: want 0.9777245237282928, got 0.009280767616650837
	regression_test.go:23: e: 0.990508
	regression_test.go:60: failed at second 3221, 2 qps
FAIL
FAIL	github.com/bmizerany/perks/quantile	3.617s
```