### PR TITLE
Use a Sample pool to avoid allocations.

### DIFF
--- a/quantile/pool.go
+++ b/quantile/pool.go
@@ -1,0 +1,28 @@
+//+build !go1.3
+
+package quantile
+
+type samplePool struct {
+	pool chan *Sample
+}
+
+func newSamplePool(capacity int) *samplePool {
+	return &samplePool{pool: make(chan *Sample, capacity)}
+}
+
+func (sp *samplePool) Get(value, width, delta float64) *Sample {
+	select {
+	case sample := <-sp.pool:
+		sample.Value, sample.Width, sample.Delta = value, width, delta
+		return sample
+	default:
+		return &Sample{value, width, delta}
+	}
+}
+
+func (sp *samplePool) Put(sample *Sample) {
+	select {
+	case sp.pool <- sample:
+	default:
+	}
+}

--- a/quantile/pool_1_3.go
+++ b/quantile/pool_1_3.go
@@ -1,0 +1,26 @@
+//+build go1.3
+
+package quantile
+
+import "sync"
+
+// With the Go1.3 sync Pool, there is no max capacity, and a globally shared
+// pool is more efficient.
+var globalSamplePool = sync.Pool{New: func() interface{} { return &Sample{} }}
+
+type samplePool struct{}
+
+func newSamplePool(capacity int) *samplePool {
+	// capacity ignored for Go1.3 sync.Pool.
+	return &samplePool{}
+}
+
+func (_ samplePool) Get(value, width, delta float64) *Sample {
+	sample := globalSamplePool.Get().(*Sample)
+	sample.Value, sample.Width, sample.Delta = value, width, delta
+	return sample
+}
+
+func (_ samplePool) Put(sample *Sample) {
+	globalSamplePool.Put(sample)
+}


### PR DESCRIPTION
With the current state, inserting is pretty heavy on the GC. On
average, 1 alloc happens per insert. In situations where you want to
handle millions of inserts in a short time, that's more or less
prohibitive.

The Sample pool implemented here can be replaced by Go 1.3 pools once
dependency on 1.3 is acceptable.

Benchmarks:

```
$ go test -bench=. -benchmem
PASS
BenchmarkInsertTargeted 10000000               159 ns/op              32 B/op          1 allocs/op
BenchmarkInsertTargetedSmallEpsilon      5000000               374 ns/op              32 B/op          1 allocs/op
BenchmarkInsertBiased   10000000               165 ns/op              32 B/op          1 allocs/op
BenchmarkInsertBiasedSmallEpsilon        5000000               877 ns/op              32 B/op          1 allocs/op
BenchmarkQuery  20000000                87.1 ns/op             0 B/op          0 allocs/op
BenchmarkQuerySmallEpsilon        500000              6046 ns/op               0 B/op          0 allocs/op
ok      github.com/bmizerany/perks/quantile     19.193s

$ go test -bench=. -benchmem
PASS
BenchmarkInsertTargeted 10000000               158 ns/op               0 B/op          0 allocs/op
BenchmarkInsertTargetedSmallEpsilon      5000000               363 ns/op               0 B/op          0 allocs/op
BenchmarkInsertBiased   10000000               158 ns/op               0 B/op          0 allocs/op
BenchmarkInsertBiasedSmallEpsilon        5000000               798 ns/op               0 B/op          0 allocs/op
BenchmarkQuery  20000000                82.5 ns/op             0 B/op          0 allocs/op
BenchmarkQuerySmallEpsilon        500000              4759 ns/op               0 B/op          0 allocs/op
ok      github.com/bmizerany/perks/quantile     17.783s
```
