### PR TITLE
fix a degenerate case in topk

### DIFF
--- a/topk/topk.go
+++ b/topk/topk.go
@@ -5,7 +5,9 @@ import (
 	"sort"
 )
 
-// http://www.cs.ucsb.edu/research/tech_reports/reports/2005-23.pdf
+// An implementation of the SpaceSaving algorithm by Metwally et al
+//
+// https://icmi.cs.ucsb.edu/research/tech_reports/reports/2005-23.pdf
 
 type Element struct {
 	Value string

--- a/topk/topk_test.go
+++ b/topk/topk_test.go
@@ -61,24 +61,31 @@ func TestTopElements(t *testing.T) {
 		}
 	}
 
-	// Insert 1 twice more so that "2" is the smallest element with a count of 2,
-	// and then insert N * 2 four times. "2" should drop out of the top k, and
-	// N * 2 should appear in the sample.
+	// Insert 1 three more times so that "2" is the smallest element with a count
+	// of 2, followed by "3" with a count of 3. Insert N * 2. "2" and "3" should
+	// not appear in the top k. N * 2 should appear with a value of 4 + 1.
 	newElement := fmt.Sprintf("%d", N*2)
 	stream.Insert("1")
 	stream.Insert("1")
-	stream.Insert(newElement)
-	stream.Insert(newElement)
-	stream.Insert(newElement)
+	stream.Insert("1")
 	stream.Insert(newElement)
 
 	var sawNewElement bool
 	for _, sample := range stream.Query() {
-		if sample.Value == "2" {
-			t.Fatalf("expected 2 to drop")
-		}
-		if sample.Value == newElement {
+		switch sample.Value {
+		case "2", "3":
+			t.Fatalf("saw elements that should have dropped")
+		case "1":
+			if sample.Count != 4 {
+				t.Fatalf("expected '1' to have a count of 4")
+			}
+		case newElement:
 			sawNewElement = true
+			if sample.Count != 5 {
+				t.Fatalf("expected new element to have a count of 5")
+			}
+		default:
+			// Do nothing.
 		}
 	}
 	if !sawNewElement {

--- a/topk/topk_test.go
+++ b/topk/topk_test.go
@@ -23,7 +23,7 @@ func TestTopK(t *testing.T) {
 
 	var sm Samples
 	for x, s := range m {
-		sm = append(sm, &Element{x, s})
+		sm = append(sm, &Element{Value: x, Count: s})
 	}
 	sort.Sort(sort.Reverse(sm))
 

--- a/topk/topk_test.go
+++ b/topk/topk_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"sort"
+	"strconv"
 	"testing"
 )
 
@@ -37,9 +38,57 @@ func TestTopK(t *testing.T) {
 	}
 }
 
+func TestTopElements(t *testing.T) {
+	N := 4
+
+	// A stream keeps N+1 items internally, so prime it with N+1 items. Use the
+	// integers 1 to N+1 and give int n frequency n.
+	stream := New(N)
+	for i := 1; i <= N+1; i++ {
+		for j := 0; j < i; j++ {
+			stream.Insert(fmt.Sprintf("%d", i))
+		}
+	}
+
+	// Make sure the insertion went ok.
+	for _, sample := range stream.Query() {
+		actual, err := strconv.Atoi(sample.Value)
+		if err != nil {
+			panic(err)
+		}
+		if actual != sample.Count {
+			t.Fatalf("expected element %s to have value %d: got %d", sample.Value, actual, sample.Count)
+		}
+	}
+
+	// Insert 1 twice more so that "2" is the smallest element with a count of 2,
+	// and then insert N * 2 four times. "2" should drop out of the top k, and
+	// N * 2 should appear in the sample.
+	newElement := fmt.Sprintf("%d", N*2)
+	stream.Insert("1")
+	stream.Insert("1")
+	stream.Insert(newElement)
+	stream.Insert(newElement)
+	stream.Insert(newElement)
+	stream.Insert(newElement)
+
+	var sawNewElement bool
+	for _, sample := range stream.Query() {
+		if sample.Value == "2" {
+			t.Fatalf("expected 2 to drop")
+		}
+		if sample.Value == newElement {
+			sawNewElement = true
+		}
+	}
+	if !sawNewElement {
+		t.Fatalf("didn't see newly inserted element in the topk")
+	}
+}
+
 func TestQuery(t *testing.T) {
 	queryTests := []struct {
-		value string
+		value    string
 		expected int
 	}{
 		{"a", 1},


### PR DESCRIPTION
I found a degenerate case in topk, added a test for it, and fixed it.
### The bug

Suppose you have the following item frequencies:

``` go
map[string]int{
        "a": 123,
        "d": 99,
        "e": 87,
        "b": 45,
        "c": 42
}
```

If the next 6 items in the stream are [c, c, c, c, c, c], the Stream will have a count of 48 for c and 45 for b, but `min` will still point to `"c"` when it should be pointing to `"b"`.

At this point if you add a new item, `"f"`, it will replace `"c"` instead of replacing `"b"` even though `"c"` has a higher count.
### The fix

Keep a reference to the actual minimum Element at all times using `container/heap`.

(This is #3 with cleaner commits, but two years later. Sorry about the delay.)
